### PR TITLE
对部分由define定义的常量进行判断，以适用于自动化集成单元测试

### DIFF
--- a/PhpunitHelper.php
+++ b/PhpunitHelper.php
@@ -8,8 +8,6 @@
  */
 namespace Think;
 
-use Snowair\Think\Phpunit\Response;
-
 class PhpunitHelper {
 
     protected static $_map=[];
@@ -34,15 +32,15 @@ class PhpunitHelper {
         if ($think_path===null) {
             $think_path = $const['THINK_PATH'];
         }
-        if ($runtime_path===null) {
+        if ($runtime_path === null) {
             $runtime_path = $const['ROOT_PATH'].'/Runtime-test';
         }
 
-        if (!file_exists( $app_path )) {
+        if (!file_exists($app_path)) {
             throw new \RuntimeException($app_path.'不存在');
         }
 
-        if (!file_exists( $think_path )) {
+        if (!file_exists($think_path)) {
             throw new \RuntimeException($think_path.'不存在');
         }
 
@@ -51,14 +49,18 @@ class PhpunitHelper {
             if (!$bool) {
                 throw new \RuntimeException($runtime_path.'创建失败');
             }
-        }else if (!is_writable( $runtime_path )) {
+        } else if (!is_writable($runtime_path)) {
             throw new \RuntimeException($runtime_path.'不可写');
         }
 
-        define ( 'APP_DEBUG', true );
-        define ( 'APP_PATH', rtrim($app_path,'\\/').'/' );
-        define ( 'RUNTIME_PATH', rtrim($runtime_path,'\\/').'/' );
-        define ( 'THINK_PATH',rtrim($think_path,'\\/').'/');
+        /**
+         * 单元测试,会出现变量重复定义错误,使用defined来判断
+         */
+        defined('APP_DEBUG')    or define('APP_DEBUG', true);
+        defined('APP_PATH')     or define('APP_PATH', rtrim($app_path, '\\/') . '/');
+        defined('RUNTIME_PATH') or define('RUNTIME_PATH', rtrim($runtime_path, '\\/') . '/');
+        defined('THINK_PATH')   or define('THINK_PATH', rtrim($think_path, '\\/') . '/');
+
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $_SERVER['REMOTE_ADDR']='127.0.0.1';
         $_SERVER['REMOTE_PORT']='32800';
@@ -71,7 +73,7 @@ class PhpunitHelper {
 
     public function guessPath()
     {
-        defined('DS') || define('DS',DIRECTORY_SEPARATOR);
+        defined('DS') || define('DS', DIRECTORY_SEPARATOR);
         $vendorPath   = dirname(dirname(__DIR__));
         $vendorParent = realpath(dirname($vendorPath));
         $rootPath = $this->getProjectRoot($vendorParent);
@@ -79,14 +81,14 @@ class PhpunitHelper {
         if ($rootPath) {
             $dir = dir($rootPath);
             $index = $basepath = false;
-            while($d=$dir->read()){
+            while ($d = $dir->read()) {
                 if($d=='index.php'){
                     $basepath = $rootPath;
                     $index = $rootPath.DS.'index.php';
                     break;
                 }
-                if(file_exists($rootPath.DS.$d.DS.'index.php') ){
-                    $basepath = $rootPath.DS.$d;
+                if (file_exists($rootPath . DS . $d . DS . 'index.php')) {
+                    $basepath = $rootPath . DS . $d;
                     $index = $rootPath.DS.$d.DS.'index.php';
                     break;
                 }
@@ -97,11 +99,11 @@ class PhpunitHelper {
                     foreach ($matches as $value) {
                         $const[$value[1]]=$value[2];
                     }
-                    if ( preg_match( '{.*[\'"](.*ThinkPHP.php)[\'"]}',$content,$matches ) ) {
+                    if (preg_match('{.*[\'"](.*ThinkPHP.php)[\'"]}', $content, $matches)) {
                         $think_path = dirname(realpath($basepath.DS.$matches[1]));
                         $const['THINK_PATH'] = $think_path;
                     }
-                    if (!file_exists( $const['APP_PATH'] )) {
+                    if (!file_exists($const['APP_PATH'])) {
                         $const['APP_PATH'] = realpath($rootPath.DIRECTORY_SEPARATOR.$const['APP_PATH']) ;
                     }
                 }
@@ -119,13 +121,13 @@ class PhpunitHelper {
      * @param string $request_scheme
      * @param string $server_port
      */
-    public function setMVC($http_host,$module_name,$controller_name,$request_scheme='http',$server_port='80')
+    public function setMVC($http_host, $module_name, $controller_name, $request_scheme = 'http', $server_port = '80')
     {
-        $this->setServerEnv('SERVER_NAME',$http_host);
-        $this->setServerEnv('HTTP_HOST',$http_host);
-        $this->setServerEnv('REQUEST_SCHEME',$request_scheme);
-        $this->setServerEnv('SERVER_PORT',$server_port);
-        defined('MODULE_NAME') or define('MODULE_NAME', $module_name );
+        $this->setServerEnv('SERVER_NAME', $http_host);
+        $this->setServerEnv('HTTP_HOST', $http_host);
+        $this->setServerEnv('REQUEST_SCHEME', $request_scheme);
+        $this->setServerEnv('SERVER_PORT', $server_port);
+        defined('MODULE_NAME') or define('MODULE_NAME', $module_name);
         defined('CONTROLLER_NAME') or define('CONTROLLER_NAME', $controller_name);
     }
 
@@ -134,9 +136,9 @@ class PhpunitHelper {
      * @param $name
      * @param $value
      */
-    public function defineConst( $name, $value )
+    public function defineConst($name, $value)
     {
-        defined($name) or define ( $name, $value );
+        defined($name) or define($name, $value);
     }
 
     /**
@@ -145,10 +147,10 @@ class PhpunitHelper {
      *
      * @return $this
      */
-    public function defineConsts( array $map )
+    public function defineConsts(array $map)
     {
         foreach ($map as $name => $value) {
-            defined($name) or define ( $name, $value );
+            defined($name) or define($name, $value);
         }
         return $this;
     }
@@ -158,7 +160,7 @@ class PhpunitHelper {
      * @param $name
      * @param $value
      */
-    public function setServerEnv( $name, $value )
+    public function setServerEnv($name, $value)
     {
         $_SERVER[$name] = $value;
     }
@@ -169,7 +171,7 @@ class PhpunitHelper {
      *
      * @return $this
      */
-    public function setServerEnvs(array $map )
+    public function setServerEnvs(array $map)
     {
         foreach ($map as $name => $value) {
             $_SERVER[$name] = $value;
@@ -181,20 +183,20 @@ class PhpunitHelper {
      * 设置 $_GET 变量
      * @param $get
      */
-    public function setGET( $get )
+    public function setGET($get)
     {
-        $_GET = array_merge($_GET,$get);
-        $_REQUEST=array_merge($_REQUEST,$_GET);
+        $_GET = array_merge($_GET, $get);
+        $_REQUEST = array_merge($_REQUEST, $_GET);
     }
 
     /**
      * 设置 $_POST变量
      * @param $post
      */
-    public function setPOST( $post )
+    public function setPOST($post)
     {
-        $_POST = array_merge($_POST,$post);
-        $_REQUEST=array_merge($_REQUEST,$_POST);
+        $_POST = array_merge($_POST, $post);
+        $_REQUEST = array_merge($_REQUEST, $_POST);
     }
 
     /**
@@ -203,28 +205,29 @@ class PhpunitHelper {
      * @param $request
      * @param $merge_post
      */
-    public function setRequest( $request, $merge_post=true )
+    public function setRequest($request, $merge_post = true)
     {
         $this->setGET($request);
         if ($merge_post) {
-            $this->setPOST( $request );
+            $this->setPOST($request);
         }
     }
 
     /**
      * 定义核心常量
      */
-    private function _defineConsts() {
+    private function _defineConsts()
+    {
 
         $GLOBALS['_beginTime'] = microtime(TRUE);
         // 记录内存初始使用
-        define('MEMORY_LIMIT_ON',function_exists('memory_get_usage'));
-        if(MEMORY_LIMIT_ON) $GLOBALS['_startUseMems'] = memory_get_usage();
+        defined('MEMORY_LIMIT_ON')  or define('MEMORY_LIMIT_ON', function_exists('memory_get_usage'));
+        if (MEMORY_LIMIT_ON) $GLOBALS['_startUseMems'] = memory_get_usage();
 
-        define( 'THINK_VERSION', '3.2.3');
+        defined('THINK_VERSION')    or define('THINK_VERSION', '3.2.3');
 
         if(function_exists('saeAutoLoader')){// 自动识别SAE环境
-            defined('APP_MODE')     or define('APP_MODE',      'sae');
+            defined('APP_MODE')     or define('APP_MODE', 'sae');
             defined('STORAGE_TYPE') or define('STORAGE_TYPE',  'Sae');
         }else{
             defined('APP_MODE')     or define('APP_MODE',       'common'); // 应用模式 默认为普通模式
@@ -232,42 +235,42 @@ class PhpunitHelper {
         }
 
         // URL 模式定义
-        define('URL_COMMON'  ,   0);  //普通模式
-        define('URL_PATHINFO',   1);  //PATHINFO模式
-        define('URL_REWRITE' ,   2);  //REWRITE模式
-        define('URL_COMPAT'  ,   3);  // 兼容模式
+        defined('URL_COMMON')       or define('URL_COMMON', 0);  //普通模式
+        defined('URL_PATHINFO')     or define('URL_PATHINFO', 1);  //PATHINFO模式
+        defined('URL_REWRITE')      or define('URL_REWRITE', 2);  //REWRITE模式
+        defined('URL_COMPAT')       or define('URL_COMPAT', 3);  // 兼容模式
 
-        defined('EXT') or define('EXT','.class.php');
+        defined('EXT')              or define('EXT', '.class.php');
 
         // 系统常量定义
-        defined('APP_PATH')     or define('APP_PATH',       dirname($_SERVER['SCRIPT_FILENAME']).'/');
-        defined('APP_STATUS')   or define('APP_STATUS',     ''); // 应用状态 加载对应的配置文件
-        defined('APP_DEBUG')    or define('APP_DEBUG',      true); // 是否调试模式
+        defined('APP_PATH')         or define('APP_PATH', dirname($_SERVER['SCRIPT_FILENAME']) . '/');
+        defined('APP_STATUS')       or define('APP_STATUS', ''); // 应用状态 加载对应的配置文件
+        defined('APP_DEBUG')        or define('APP_DEBUG', true); // 是否调试模式
 
-        defined('RUNTIME_PATH') or define('RUNTIME_PATH',   APP_PATH.'Runtime/');   // 系统运行时目录
-        defined('LIB_PATH')     or define('LIB_PATH',       realpath(THINK_PATH.'Library').'/'); // 系统核心类库目录
-        defined('CORE_PATH')    or define('CORE_PATH',      LIB_PATH.'Think/'); // Think类库目录
-        defined('BEHAVIOR_PATH')or define('BEHAVIOR_PATH',  LIB_PATH.'Behavior/'); // 行为类库目录
-        defined('MODE_PATH')    or define('MODE_PATH',      THINK_PATH.'Mode/'); // 系统应用模式目录
-        defined('VENDOR_PATH')  or define('VENDOR_PATH',    LIB_PATH.'Vendor/'); // 第三方类库目录
-        defined('COMMON_PATH')  or define('COMMON_PATH',    APP_PATH.'Common/'); // 应用公共目录
-        defined('CONF_PATH')    or define('CONF_PATH',      COMMON_PATH.'Conf/'); // 应用配置目录
-        defined('LANG_PATH')    or define('LANG_PATH',      COMMON_PATH.'Lang/'); // 应用语言目录
-        defined('HTML_PATH')    or define('HTML_PATH',      APP_PATH.'Html/'); // 应用静态目录
-        defined('LOG_PATH')     or define('LOG_PATH',       RUNTIME_PATH.'Logs/'); // 应用日志目录
-        defined('TEMP_PATH')    or define('TEMP_PATH',      RUNTIME_PATH.'Temp/'); // 应用缓存目录
-        defined('DATA_PATH')    or define('DATA_PATH',      RUNTIME_PATH.'Data/'); // 应用数据目录
-        defined('CACHE_PATH')   or define('CACHE_PATH',     RUNTIME_PATH.'Cache/'); // 应用模板缓存目录
-        defined('CONF_EXT')     or define('CONF_EXT',       '.php'); // 配置文件后缀
-        defined('CONF_PARSE')   or define('CONF_PARSE',     '');    // 配置文件解析方法
-        defined('ADDON_PATH')   or define('ADDON_PATH',     APP_PATH.'Addon');
+        defined('RUNTIME_PATH')     or define('RUNTIME_PATH', APP_PATH . 'Runtime/');   // 系统运行时目录
+        defined('LIB_PATH')         or define('LIB_PATH',       realpath(THINK_PATH.'Library').'/'); // 系统核心类库目录
+        defined('CORE_PATH')        or define('CORE_PATH',      LIB_PATH.'Think/'); // Think类库目录
+        defined('BEHAVIOR_PATH')    or define('BEHAVIOR_PATH',  LIB_PATH.'Behavior/'); // 行为类库目录
+        defined('MODE_PATH')        or define('MODE_PATH',      THINK_PATH.'Mode/'); // 系统应用模式目录
+        defined('VENDOR_PATH')      or define('VENDOR_PATH',    LIB_PATH.'Vendor/'); // 第三方类库目录
+        defined('COMMON_PATH')      or define('COMMON_PATH',    APP_PATH.'Common/'); // 应用公共目录
+        defined('CONF_PATH')        or define('CONF_PATH',      COMMON_PATH.'Conf/'); // 应用配置目录
+        defined('LANG_PATH')        or define('LANG_PATH', COMMON_PATH . 'Lang/'); // 应用语言目录
+        defined('HTML_PATH')        or define('HTML_PATH',      APP_PATH.'Html/'); // 应用静态目录
+        defined('LOG_PATH')         or define('LOG_PATH',       RUNTIME_PATH.'Logs/'); // 应用日志目录
+        defined('TEMP_PATH')        or define('TEMP_PATH',      RUNTIME_PATH.'Temp/'); // 应用缓存目录
+        defined('DATA_PATH')        or define('DATA_PATH',      RUNTIME_PATH.'Data/'); // 应用数据目录
+        defined('CACHE_PATH')       or define('CACHE_PATH',     RUNTIME_PATH.'Cache/'); // 应用模板缓存目录
+        defined('CONF_EXT')         or define('CONF_EXT',       '.php'); // 配置文件后缀
+        defined('CONF_PARSE')       or define('CONF_PARSE', '');    // 配置文件解析方法
+        defined('ADDON_PATH')       or define('ADDON_PATH',     APP_PATH.'Addon');
 
         // 系统信息
         if(version_compare(PHP_VERSION,'5.4.0','<')) {
             ini_set('magic_quotes_runtime',0);
-            define('MAGIC_QUOTES_GPC',get_magic_quotes_gpc()?True:False);
+            defined('MAGIC_QUOTES_GPC') or define('MAGIC_QUOTES_GPC', get_magic_quotes_gpc() ? True : False);
         }else{
-            define('MAGIC_QUOTES_GPC',false);
+            defined('MAGIC_QUOTES_GPC') or define('MAGIC_QUOTES_GPC', false);
         }
 
         defined('IS_CGI')   or define('IS_CGI',0);
@@ -282,12 +285,12 @@ class PhpunitHelper {
                     $_temp  = explode('.php',$_SERVER['PHP_SELF']);
                     define('_PHP_FILE_', rtrim(str_replace($_SERVER['HTTP_HOST'],'',$_temp[0].'.php'),'/'));
                 }else {
-                    define('_PHP_FILE_', rtrim($_SERVER['SCRIPT_NAME'],'/'));
+                    define('_PHP_FILE_', rtrim($_SERVER['SCRIPT_NAME'], '/'));
                 }
             }
 
             if(!defined('__ROOT__')) {
-                $_root  =   rtrim(dirname(_PHP_FILE_),'/');
+                $_root = rtrim(dirname(_PHP_FILE_), '/');
                 define('__ROOT__',  (($_root=='/' || $_root=='\\')?'':$_root));
             }
         }
@@ -303,29 +306,29 @@ class PhpunitHelper {
         register_shutdown_function('\\Think\\PhpunitHelper::fatalError');
         Storage::connect(STORAGE_TYPE);
 
-        $mode   =   include is_file(CONF_PATH.'core.php')?CONF_PATH.'core.php':MODE_PATH.APP_MODE.'.php';
+        $mode = include is_file(CONF_PATH . 'core.php') ? CONF_PATH . 'core.php' : MODE_PATH . APP_MODE . '.php';
         // 加载核心文件
-        foreach ($mode['core'] as $file){
+        foreach ($mode['core'] as $file) {
             if(is_file($file)) {
-                if ( strpos( $file, 'Think/Controller.class.php' )!==false
+                if (strpos($file, 'Think/Controller.class.php') !== false
                     ||strpos( $file, 'Think\\Controller.class.php' )!==false
-                    ||strpos( $file, 'Think/View.class.php' )!==false
-                    ||strpos( $file, 'Think\\View.class.php' )!==false
+                    || strpos($file, 'Think/View.class.php') !== false
+                    || strpos($file, 'Think\\View.class.php') !== false
                 ) {
                     // not include
-                }else{
+                } else {
                     include_once $file;
                 }
             }
         }
         // 加载应用模式配置文件
-        foreach ($mode['config'] as $key=>$file){
-            is_numeric($key)?C(load_config($file)):C($key,load_config($file));
+        foreach ($mode['config'] as $key => $file) {
+            is_numeric($key) ? C(load_config($file)) : C($key, load_config($file));
         }
 
         // 读取当前应用模式对应的配置文件
-        if('common' != APP_MODE && is_file(CONF_PATH.'config_'.APP_MODE.CONF_EXT)){
-            C(load_config(CONF_PATH.'config_'.APP_MODE.CONF_EXT));
+        if ('common' != APP_MODE && is_file(CONF_PATH . 'config_' . APP_MODE . CONF_EXT)) {
+            C(load_config(CONF_PATH . 'config_' . APP_MODE . CONF_EXT));
         }
 
         // 加载模式别名定义
@@ -340,11 +343,11 @@ class PhpunitHelper {
 
         // 加载模式行为定义
         if(isset($mode['tags'])) {
-            \Think\Hook::import(is_array($mode['tags'])?$mode['tags']:include $mode['tags']);
+            \Think\Hook::import(is_array($mode['tags']) ? $mode['tags'] : include $mode['tags']);
         }
 
         // 加载应用行为定义
-        if(is_file(CONF_PATH.'tags.php')){
+        if (is_file(CONF_PATH . 'tags.php')) {
             // 允许应用增加开发模式配置定义
             \Think\Hook::import(include CONF_PATH.'tags.php');
         }
@@ -354,12 +357,12 @@ class PhpunitHelper {
         // 调试模式加载系统默认的配置文件
         C(include THINK_PATH.'Conf/debug.php');
         // 读取应用调试配置文件
-        if(is_file(CONF_PATH.'debug'.CONF_EXT)){
-            C(include CONF_PATH.'debug'.CONF_EXT);
+        if (is_file(CONF_PATH . 'debug' . CONF_EXT)) {
+            C(include CONF_PATH . 'debug' . CONF_EXT);
         }
         C('HTML_CACHE_ON',false);
         C('LIMIT_ROBOT_VISIT',false) ;
-        C('LIMIT_PROXY_VISIT',false);
+        C('LIMIT_PROXY_VISIT', false);
         $this->run();
     }
 
@@ -390,7 +393,7 @@ class PhpunitHelper {
         $test_db_name = C('DB_NAME'); // 测试数据库的数据库名
         $test_db_host = C('DB_HOST'); // 应用使用的数据库名
         if (
-            ($db_name && $db_name==$test_db_name)
+            ($db_name && $db_name == $test_db_name)
            && ($db_host && $db_host==$test_db_host)
         ) {
             throw new \Exception('请单独为测试环境设置数据库连接配置');
@@ -414,33 +417,33 @@ class PhpunitHelper {
         C('LOG_PATH',   realpath(LOG_PATH).'/Common/');
 
         // 定义当前请求的系统常量
-        define('NOW_TIME',      $_SERVER['REQUEST_TIME']);
-        define('REQUEST_METHOD',$_SERVER['REQUEST_METHOD']);
-        defined('IS_GET')    || define('IS_GET',        REQUEST_METHOD =='GET' ? true : false);
-        defined('IS_POST')   || define('IS_POST',       REQUEST_METHOD =='POST' ? true : false);
-        defined('IS_PUT')    || define('IS_PUT',        REQUEST_METHOD =='PUT' ? true : false);
-        defined('IS_DELETE') || define('IS_DELETE',     REQUEST_METHOD =='DELETE' ? true : false);
+        defined('NOW_TIME')         or define('NOW_TIME', $_SERVER['REQUEST_TIME']);
+        defined('REQUEST_METHOD')   or define('REQUEST_METHOD', $_SERVER['REQUEST_METHOD']);
+        defined('IS_GET')           || define('IS_GET', REQUEST_METHOD == 'GET' ? true : false);
+        defined('IS_POST')          || define('IS_POST', REQUEST_METHOD == 'POST' ? true : false);
+        defined('IS_PUT')           || define('IS_PUT', REQUEST_METHOD == 'PUT' ? true : false);
+        defined('IS_DELETE')        || define('IS_DELETE', REQUEST_METHOD == 'DELETE' ? true : false);
 
         // URL调度
         $this->dispatch();
 
-        if(C('REQUEST_VARS_FILTER')){
+        if (C('REQUEST_VARS_FILTER')) {
             // 全局安全过滤
-            array_walk_recursive($_GET,		'think_filter');
-            array_walk_recursive($_POST,	'think_filter');
-            array_walk_recursive($_REQUEST,	'think_filter');
+            array_walk_recursive($_GET, 'think_filter');
+            array_walk_recursive($_POST, 'think_filter');
+            array_walk_recursive($_REQUEST, 'think_filter');
         }
 
         // URL调度结束标签
         \Think\Hook::listen('url_dispatch');
 
         // TMPL_EXCEPTION_FILE 改为绝对地址
-        C('TMPL_EXCEPTION_FILE',realpath(C('TMPL_EXCEPTION_FILE')));
+        C('TMPL_EXCEPTION_FILE', realpath(C('TMPL_EXCEPTION_FILE')));
         defined('IS_AJAX') or define(
             'IS_AJAX',
-            ( (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest')
-                || !empty($_POST[C('VAR_AJAX_SUBMIT')])
-                || !empty($_GET[C('VAR_AJAX_SUBMIT')])
+        ((isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest')
+            || !empty($_POST[C('VAR_AJAX_SUBMIT')])
+            || !empty($_GET[C('VAR_AJAX_SUBMIT')])
             ) ? true : false
         );
         C('phpunit',true);
@@ -459,64 +462,64 @@ class PhpunitHelper {
 
     protected function dispatch()
     {
-        $urlCase        =   C('URL_CASE_INSENSITIVE');
+        $urlCase = C('URL_CASE_INSENSITIVE');
 
         // 定义当前模块路径
-        define('MODULE_PATH', APP_PATH.MODULE_NAME.'/');
+        defined('MODULE_PATH') or define('MODULE_PATH', APP_PATH . MODULE_NAME . '/');
         // 定义当前模块的模版缓存路径
-        C('CACHE_PATH',CACHE_PATH.MODULE_NAME.'/');
+        C('CACHE_PATH', CACHE_PATH . MODULE_NAME . '/');
         if (!file_exists(LOG_PATH)) {
-            mkdir(LOG_PATH,0755);
+            mkdir(LOG_PATH, 0755);
         }
-        C('LOG_PATH',  realpath(LOG_PATH).'/'.MODULE_NAME.'/');
+        C('LOG_PATH', realpath(LOG_PATH) . '/' . MODULE_NAME . '/');
 
         // 模块检测
         Hook::listen('module_check');
 
         // 加载模块配置文件
-        if(is_file(MODULE_PATH.'Conf/config.php')){
-            C(include MODULE_PATH.'Conf/config.php');
+        if (is_file(MODULE_PATH . 'Conf/config.php')) {
+            C(include MODULE_PATH . 'Conf/config.php');
         }
         // 加载模块别名定义
         if(is_file(MODULE_PATH.'Conf/alias.php')){
-            $map = include MODULE_PATH.'Conf/alias.php';
+            $map = include MODULE_PATH . 'Conf/alias.php';
             foreach ($map as $class => $file) {
                 include $file;
             }
         }
         // 加载模块函数文件
-        if(is_file(MODULE_PATH.'Common/function.php')){
-            include MODULE_PATH.'Common/function.php';
+        if (is_file(MODULE_PATH . 'Common/function.php')) {
+            include MODULE_PATH . 'Common/function.php';
         }
         // 加载模块的扩展配置文件
         load_ext_file(MODULE_PATH);
 
         $depr = C('URL_PATHINFO_DEPR');
-        define('MODULE_PATHINFO_DEPR',  $depr);
+        defined('MODULE_PATHINFO_DEPR') or define('MODULE_PATHINFO_DEPR', $depr);
 
         if(!defined('__APP__')){
             $urlMode        =   C('URL_MODEL');
-            if($urlMode == URL_COMPAT ){// 兼容模式判断
-                $varPath        =   C('VAR_PATHINFO');
-                defined('PHP_FILE') ||define('PHP_FILE',_PHP_FILE_.'?'.$varPath.'=');
-            }elseif($urlMode == URL_REWRITE ) {
-                $url    =   dirname(_PHP_FILE_);
-                if($url == '/' || $url == '\\')
-                    $url    =   '';
-                defined('PHP_FILE') ||define('PHP_FILE',$url);
-            }else {
-                defined('PHP_FILE') ||define('PHP_FILE',_PHP_FILE_);
+            if ($urlMode == URL_COMPAT) {// 兼容模式判断
+                $varPath = C('VAR_PATHINFO');
+                defined('PHP_FILE') || define('PHP_FILE', _PHP_FILE_ . '?' . $varPath . '=');
+            } elseif ($urlMode == URL_REWRITE) {
+                $url = dirname(_PHP_FILE_);
+                if ($url == '/' || $url == '\\')
+                    $url = '';
+                defined('PHP_FILE') || define('PHP_FILE', $url);
+            } else {
+                defined('PHP_FILE') || define('PHP_FILE', _PHP_FILE_);
             }
             // 当前应用地址
-            defined('__APP__') ||define('__APP__',strip_tags(PHP_FILE));
+            defined('__APP__') || define('__APP__', strip_tags(PHP_FILE));
         }
 
-        $moduleName    =   MODULE_NAME;
-        $controllerName =   CONTROLLER_NAME;
-        define('__MODULE__',(defined('BIND_MODULE') || !C('MULTI_MODULE'))? __APP__ : __APP__.'/'.($urlCase ? strtolower($moduleName) : $moduleName));
-        define('__CONTROLLER__',__MODULE__.$depr.(defined('BIND_CONTROLLER')? '': ( $urlCase ? parse_name($controllerName) : $controllerName )) );
-        defined('__ACTION__') || define('__ACTION__',__CONTROLLER__.$depr.$this->action_name);
-        defined('__SELF__') || define('__SELF__',strip_tags(isset($_SERVER[C('URL_REQUEST_URI')])?$_SERVER[C('URL_REQUEST_URI')]:''));
+        $moduleName = MODULE_NAME;
+        $controllerName = CONTROLLER_NAME;
+        defined('__MODULE__')       or define('__MODULE__', (defined('BIND_MODULE') || !C('MULTI_MODULE')) ? __APP__ : __APP__ . '/' . ($urlCase ? strtolower($moduleName) : $moduleName));
+        defined('__CONTROLLER__')   or define('__CONTROLLER__', __MODULE__ . $depr . (defined('BIND_CONTROLLER') ? '' : ($urlCase ? parse_name($controllerName) : $controllerName)));
+        defined('__ACTION__')       || define('__ACTION__', __CONTROLLER__ . $depr . $this->action_name);
+        defined('__SELF__')         || define('__SELF__', strip_tags(isset($_SERVER[C('URL_REQUEST_URI')]) ? $_SERVER[C('URL_REQUEST_URI')] : ''));
     }
 
     /**
@@ -524,10 +527,11 @@ class PhpunitHelper {
      * @param        $class
      * @param string $map
      */
-    static public function addMap($class, $map=''){
-        if(is_array($class)){
+    static public function addMap($class, $map = '')
+    {
+        if (is_array($class)) {
             self::$_map = array_merge(self::$_map, $class);
-        }else{
+        } else {
             self::$_map[$class] = $map;
         }
     }
@@ -543,7 +547,8 @@ class PhpunitHelper {
         }
     }
 
-    static public function fatalError() {
+    static public function fatalError()
+    {
         if ($e = error_get_last()) {
             print_r($e);
         }
@@ -563,7 +568,7 @@ class PhpunitHelper {
      * 但必须在start方法之前调用才有效
      * @param array $config
      */
-    public function setTestConfig(array $config )
+    public function setTestConfig(array $config)
     {
         $this->testConfig = $config;
     }
@@ -573,23 +578,23 @@ class PhpunitHelper {
      */
     protected function loadEnvConfig()
     {
-        $path =  dirname(APP_PATH);
-        $env_file = $path.'/.test.env';
+        $path = dirname(APP_PATH);
+        $env_file = $path . '/.test.env';
         if (file_exists($env_file)) {
             $Loader = new \Snowair\Dotenv\Loader($env_file);
             $Loader->setFilters(['Snowair\Dotenv\DotArrayFilter'])
                 ->parse()
                 ->filter();
-            if( $expect=C('DOTENV.expect') ){
-                call_user_func_array(array($Loader,'expect'),explode(',',$expect));
+            if ($expect = C('DOTENV.expect')) {
+                call_user_func_array(array($Loader, 'expect'), explode(',', $expect));
             }
-            if(C('DOTENV.toConst')){
+            if (C('DOTENV.toConst')) {
                 $Loader->define();
             }
             if(C('DOTENV.toServer')){
                 $Loader->toServer(true);
             }
-            if(C('DOTENV.toEnv')){
+            if (C('DOTENV.toEnv')) {
                 $Loader->toEnv(true);
             }
             $env = $Loader->toArray();
@@ -599,17 +604,17 @@ class PhpunitHelper {
 
     function getProjectRoot($vendorParent){
         $dir = dirname($vendorParent);
-        if ( file_exists($vendorParent. DS .'composer.json')
+        if (file_exists($vendorParent . DS . 'composer.json')
             || file_exists( $vendorParent.DS.'.git')
-            || file_exists( $vendorParent.DS.'.svn')
+            || file_exists($vendorParent . DS . '.svn')
             || file_exists( $vendorParent.DS.'.hg')
-            || file_exists( $vendorParent.DS.'index.php' )
+            || file_exists($vendorParent . DS . 'index.php')
         )
         {
             return $vendorParent;
-        }elseif( $dir!=$vendorParent && $dir!='.' ){
+        } elseif ($dir != $vendorParent && $dir != '.') {
             return $this->getProjectRoot($dir);
-        }else{
+        } else {
             return false;
         }
     }


### PR DESCRIPTION
在集成到Jenkins做单元测试时，会发现该文件中的一些常量被重复定义，如:APP_DEBUG.这样会导致集成测试时无法通过。原因是写单元测试用例时，每一个测试用例文件都实例化了一个PhpunitHelper对象，导致重复定义。
